### PR TITLE
Fix undefined in selector

### DIFF
--- a/iconDisplayFlow/force-app/main/default/lwc/iconDisplay/iconDisplay.js
+++ b/iconDisplayFlow/force-app/main/default/lwc/iconDisplay/iconDisplay.js
@@ -20,7 +20,7 @@ export default class IconDisplay extends LightningElement {
     }
 
     initCSSVariables() {
-        this.template.querySelector('.my-icon').style.setProperty('--backgroundColor', this.backgroundColor);
-        this.template.querySelector('.my-icon').style.setProperty('--foregroundColor', this.foregroundColor);
+        this.template.querySelector('.my-icon')?.style.setProperty('--backgroundColor', this.backgroundColor);
+        this.template.querySelector('.my-icon')?.style.setProperty('--foregroundColor', this.foregroundColor);
     }
 }


### PR DESCRIPTION
If custom colour is not set then '.my-icon' will not be applied to the component.  This causes an exception in insitCSSVariables. In this commit I use the nullsafe operator to prevent the error